### PR TITLE
delete! -> pop!

### DIFF
--- a/src/RequestParser.jl
+++ b/src/RequestParser.jl
@@ -98,7 +98,7 @@ function on_message_complete(parser)
     r.data = takebuf_string(state.data)
 
     # delete the temporary header key
-    delete!(r.headers, "current_header", nothing)
+    pop!(r.headers, "current_header", nothing)
 
     # Get the `parser.id` from the C pointer `parser`.
     # Retrieve our callback function from the global Dict.


### PR DESCRIPTION
fixing 

```
WARNING: delete!(d::Dict,key,default) is deprecated, use pop!(d,key,default) instead.
 in on_message_complete at /home/rene/.julia/HttpServer/src/RequestParser.jl:101
```
