### PR TITLE
Update HttpServer.jl

### DIFF
--- a/src/HttpServer.jl
+++ b/src/HttpServer.jl
@@ -150,7 +150,7 @@ import Base.write
 function write{T<:IO}(io::T, response::Response)
     write(io, join(["HTTP/1.1", response.status, HttpCommon.STATUS_CODES[response.status], "\r\n"], " "))
 
-    response.headers["Content-Length"] = string(length(response.data))
+    response.headers["Content-Length"] = string(sizeof(response.data))
     for header in keys(response.headers)
         write(io, string(join([ header, ": ", response.headers[header] ]), "\r\n"))
     end


### PR DESCRIPTION
A page retrieved with curl gets truncated if there are letters like ä and ö in the content (utf-8).

Use sizeof (length in bytes) instead of length (length in characters)?
