### PR TITLE
use delete! to remove "current_header"

### DIFF
--- a/src/HttpServer.jl
+++ b/src/HttpServer.jl
@@ -172,8 +172,8 @@ function write{T<:IO}(io::T, response::Response)
     write(io, join(["HTTP/1.1", response.status, HttpCommon.STATUS_CODES[response.status], "\r\n"], " "))
 
     response.headers["Content-Length"] = string(sizeof(response.data))
-    for header in keys(response.headers)
-        write(io, string(join([ header, ": ", response.headers[header] ]), "\r\n"))
+    for (header,value) in response.headers
+        write(io, string(join([ header, ": ", value ]), "\r\n"))
     end
 
     write(io, "\r\n")

--- a/src/RequestParser.jl
+++ b/src/RequestParser.jl
@@ -58,7 +58,7 @@ function on_header_value(parser, at, len)
     r = pd(parser).request
     s = bytestring(convert(Ptr{Uint8}, at),int(len))
     r.headers[r.headers["current_header"]] = s
-    r.headers["current_header"] = ""
+    delete!(r.headers, "current_header")
     return 0
 end
 
@@ -90,7 +90,7 @@ function on_message_complete(parser)
     r.data = takebuf_string(state.data)
 
     # delete the temporary header key
-    pop!(r.headers, "current_header", nothing)
+    delete!(r.headers, "current_header")
 
     # Get the `parser.id` from the C pointer `parser`.
     # Retrieve our callback function from the global Dict.


### PR DESCRIPTION
delete! works better with the upcoming HttpCommon.Headers type
