### PR TITLE
Fix `at-docstrings` deprecation warning.

### DIFF
--- a/src/HttpServer.jl
+++ b/src/HttpServer.jl
@@ -6,7 +6,7 @@ module HttpServer
 
 try
     using Docile
-    eval(:(@docstrings [:manual => ["../README.md"]]))
+    eval(:(@docstrings(manual = ["../README.md"])))
 catch
     macro doc(ex)
         esc(ex.args[2].args[2])


### PR DESCRIPTION
Some minor syntax changes were introduced today for `@docstrings` and `@doc` metadata. This PR silences the deprecation warnings. The old syntax will still be around for a while though.
