### PR TITLE
fix unqualified "@doc" for julia 0.4

### DIFF
--- a/src/HttpServer.jl
+++ b/src/HttpServer.jl
@@ -3,13 +3,21 @@
 # Serve HTTP requests in Julia.
 #
 module HttpServer
-
-try
-    using Docile
-    eval(:(@docstrings(manual = ["../README.md"])))
-catch
-    macro doc(ex)
-        esc(ex.args[2].args[2])
+if VERSION < v"0.4.0-dev"
+    try
+        using Docile
+        eval(:(@docstrings(manual = ["../README.md"])))
+    catch
+        macro doc(ex)
+            esc(ex.args[2].args[2])
+        end
+    end
+else
+    try
+        import Docile
+        eval(:(Docile.@docstrings(manual = ["../README.md"])))
+    catch e
+        println(e)
     end
 end
 


### PR DESCRIPTION
Try to fix this [issue](https://github.com/JuliaWeb/HttpServer.jl/issues/54).

My code looks ugly.... but with the same ability as the old.

May be I should simplify as below

``` Julia
if VERSION < v"0.4.0-dev"
    try
        using Docile
        eval(:(@docstrings(manual = ["../README.md"])))
    catch
        macro doc(ex)
            esc(ex.args[2].args[2])
        end
    end
end


```
