### PR TITLE
rewriting `run` call interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,24 @@
 
 This is a basic, non-blocking HTTP server in Julia.
 
-You can write a basic application using just this
-if you're happy dealing with values representing HTTP requests and responses directly.
+You can write a basic application using just this if you're happy dealing with values representing HTTP requests and responses directly.
 For a higher-level view, you could use [Meddle](https://github.com/JuliaWeb/Meddle.jl) or [Morsel](https://github.com/JuliaWeb/Morsel.jl).
 If you'd like to use WebSockets as well, you'll need to grab [WebSockets.jl](https://github.com/JuliaWeb/WebSockets.jl).
 
-**Installation**: `Pkg.add("HttpServer")`
-
-To make sure everything is working, you can run 
+##Installation
+Use Julia package manager to install this package as follows:
 ```
-cd ~/.julia/v0.3/HttpServer
-julia examples/hello.jl
+Pkg.add("HttpServer")
 ```
-If you open up `localhost:8000/hello/name/` in your browser, you should get a greeting from the server.
 
+## Functionality
+* binds to any address and port
+* supports IPv4 & IPv6 addresses
+* supports HTTP, HTTPS and Unix socket transports
 
-## Basic Example:
+You can find many examples of how to use this package in the `examples` folder.
+
+## Example
 
 ```julia
 using HttpServer
@@ -30,12 +32,12 @@ http = HttpHandler() do req::Request, res::Response
     Response( ismatch(r"^/hello/",req.resource) ? string("Hello ", split(req.resource,'/')[3], "!") : 404 )
 end
 
-http.events["error"]  = ( client, err ) -> println( err )
-http.events["listen"] = ( port )        -> println("Listening on $port...")
-
 server = Server( http )
 run( server, 8000 )
+# or
+run(server, host=IPv4(127,0,0,1), port=8000)
 ```
+If you open up `localhost:8000/hello/name/` in your browser, you should get a greeting from the server.
 
 ---
 

--- a/examples/http.jl
+++ b/examples/http.jl
@@ -1,0 +1,9 @@
+using HttpServer
+
+http = HttpHandler() do req::Request, res::Response
+    Response("Hello World")
+end
+http.events["listen"] = (saddr) -> println("Running on https://$saddr (Press CTRL+C to quit)")
+
+server = Server(http)
+run(server, host=IPv4(127,0,0,1), port=8000)

--- a/examples/https.jl
+++ b/examples/https.jl
@@ -1,0 +1,37 @@
+"""
+Example of using HttpServer with HTTPS protocol:
+
+1) Create a self-signed SSL Certificate
+    - Generate a private key
+        openssl genrsa -des3 -out server.key 1024
+
+    - Generate a CSR (Certificate Signing Request)
+        openssl req -new -key server.key -out server.csr -subj "/L=github.com/O=JuliaWeb/OU=HttpServer/CN=localhost"
+
+    - Remove Passphrase from Key
+        cp server.key server.key.org
+        openssl rsa -in server.key.org -out server.key
+
+    - Generating a Self-Signed Certificate
+        openssl x509 -req -days 365 -in server.csr -signkey server.key -out server.crt
+
+2) Add certificate/private key pair to a certificate store
+
+3) Run server with the store which contains self-signed SSL certificate
+"""
+
+# Adding certificate/private key pair to certificate store
+using GnuTLS
+cert_store = GnuTLS.CertificateStore()
+GnuTLS.load_certificate(cert_store, "server.crt", "server.key", true)
+
+# Setting up simple server
+using HttpServer
+http = HttpHandler() do req::Request, res::Response
+    Response("Hello Secure World!")
+end
+http.events["listen"] = (saddr) -> println("Running on https://$saddr (Press CTRL+C to quit)")
+
+# Running server in HTTPS mode
+server = Server(http)
+run(server, port=8000, ssl=cert_store)

--- a/examples/unix_socket.jl
+++ b/examples/unix_socket.jl
@@ -1,0 +1,9 @@
+using HttpServer
+
+http = HttpHandler(Base.PipeServer()) do req::Request, res::Response
+    Response("Hello Unix World!")
+end
+http.events["listen"] = (socket_file) -> println("Listening file $socket_file...")
+
+server = Server(http)
+run(server, socket="/tmp/julia.socket")

--- a/examples/unix_socket_client.jl
+++ b/examples/unix_socket_client.jl
@@ -1,0 +1,22 @@
+using Requests
+using HttpCommon
+using HttpParser
+
+function process_response(stream)
+    r = Response()
+    rp = Requests.ResponseParser(r,stream)
+    while isopen(stream)
+        data = readavailable(stream)
+        if length(data) > 0
+            http_parser_execute(rp.parser, rp.settings, data)
+        end
+    end
+    http_parser_execute(rp.parser,rp.settings,"") #EOF
+    r
+end
+
+clientside = connect("/tmp/julia.socket")
+req = Requests.default_request("GET", "/", "/tmp/julia.socket", "")
+dump(req)
+write(clientside, Requests.render(req))
+dump(process_response(clientside))


### PR DESCRIPTION
Rewriting `run` function call to support:
 - unified interface for `http` and `https` protocols
 - binding to any address and port
 - support for IPv4 & IPv6
 - unix socket transport 

Examples:
- HTTPS server
- Unix sockets server