### PR TITLE
Export mimetypes

### DIFF
--- a/src/HttpServer.jl
+++ b/src/HttpServer.jl
@@ -389,7 +389,7 @@ function message_handler(server::Server, client::Client, websockets_enabled::Boo
 end
 
 
-
+export mimetypes
 include("mimetypes.jl")
 
 function FileResponse(filename)


### PR DESCRIPTION
Hello,

I was debugging an issue in `Escher` and found that not exporting `mimetypes` breaks Mux. As `HttpCommon` used to export `mimetypes`, I think `HttpServer` should do it too as packages might be expecting this!

Cheers,
Rohit