### PR TITLE
Close HttpServer gracefully: Added try/catch to handle_http(s)_request and a "close" function

### DIFF
--- a/src/HttpServer.jl
+++ b/src/HttpServer.jl
@@ -233,12 +233,11 @@ function handle_http_request(server::Server)
         try
             sock = accept(server.http.sock)
         catch e
-            if isa(e,Base.UVError) && e.prefix == "accept" && e.code == Base.UV_ECONNABORTED
+            if !isopen(server.http.sock)
                 # Server was closed while waiting to accept client. Exit gracefully.
-                return
-            else
-                throw(e)
+                break
             end
+            throw(e)
         end
         client = Client(id_pool += 1, sock)
         client.parser = ClientParser(message_handler(server, client, websockets_enabled))
@@ -259,12 +258,11 @@ function handle_https_request(server::Server, ssl_config::MbedTLS.SSLConfig)
         try
             sock = accept(server.http.sock)
         catch e
-            if isa(e,Base.UVError) && e.prefix == "accept" && e.code == Base.UV_ECONNABORTED
+            if !isopen(server.http.sock)
                 # Server was closed while waiting to accept client. Exit gracefully.
-                return
-            else
-                throw(e)
+                break
             end
+            throw(e)
         end
         try
             MbedTLS.set_bio!(sess, sock)

--- a/src/HttpServer.jl
+++ b/src/HttpServer.jl
@@ -399,6 +399,7 @@ function process_client(server::Server, client::Client, websockets_enabled::Bool
     event("close", server, client)
 end
 
+""" Closes the Server `server` by closing the underlying TCPServer `sock` in the HttpHandler. """
 close(server::Server) = close(server.http.sock)
 
 "Callback factory for providing `on_message_complete` for `client.parser`"

--- a/src/HttpServer.jl
+++ b/src/HttpServer.jl
@@ -21,7 +21,7 @@ export HttpHandler,
        parsequerystring,
        setcookie!
 
-import Base: run, listen
+import Base: run, listen, close
 
 defaultevents = Dict{ASCIIString, Function}()
 defaultevents["error"]  = ( client, err )->println( err )
@@ -229,7 +229,18 @@ function handle_http_request(server::Server)
     id_pool = 0 # Increments for each connection
     websockets_enabled = server.websock != nothing
     while true # handle requests, Base.wait_accept blocks until a connection is made
-        client = Client(id_pool += 1, accept(server.http.sock))
+        sock = TCPSocket()
+        try
+            sock = accept(server.http.sock)
+        catch e
+            if isa(e,Base.UVError) && e.prefix == "accept" && e.code == Base.UV_ECONNABORTED
+                # Server was closed while waiting to accept client. Exit gracefully.
+                return
+            else
+                throw(y)
+            end
+        end
+        client = Client(id_pool += 1, sock)
         client.parser = ClientParser(message_handler(server, client, websockets_enabled))
         @async process_client(server, client, websockets_enabled)
     end
@@ -242,17 +253,27 @@ function handle_https_request(server::Server, ssl_config::MbedTLS.SSLConfig)
     while true
         sess = MbedTLS.SSLContext()
         MbedTLS.setup!(sess, ssl_config)
+        sock = TCPSocket()
         # set_priority_string!(sess)
         # set_credentials!(sess, cert_store)
-        client = accept(server.http.sock)
         try
-            MbedTLS.set_bio!(sess, client)
+            sock = accept(server.http.sock)
+        catch e
+            if isa(e,Base.UVError) && e.prefix == "accept" && e.code == Base.UV_ECONNABORTED
+                # Server was closed while waiting to accept client. Exit gracefully.
+                return
+            else
+                throw(y)
+            end
+        end
+        try
+            MbedTLS.set_bio!(sess, sock)
             MbedTLS.handshake(sess)
             # associate_stream(sess, client)
             # handshake!(sess)
         catch e
             println("Error establishing SSL connection: ", e)
-            close(client)
+            close(sock)
             continue
         end
         client = Client(id_pool += 1, sess)
@@ -377,6 +398,8 @@ function process_client(server::Server, client::Client, websockets_enabled::Bool
     end
     event("close", server, client)
 end
+
+close(server::Server) = close(server.http.sock)
 
 "Callback factory for providing `on_message_complete` for `client.parser`"
 function message_handler(server::Server, client::Client, websockets_enabled::Bool)

--- a/src/HttpServer.jl
+++ b/src/HttpServer.jl
@@ -237,7 +237,7 @@ function handle_http_request(server::Server)
                 # Server was closed while waiting to accept client. Exit gracefully.
                 return
             else
-                throw(y)
+                throw(e)
             end
         end
         client = Client(id_pool += 1, sock)
@@ -263,7 +263,7 @@ function handle_https_request(server::Server, ssl_config::MbedTLS.SSLConfig)
                 # Server was closed while waiting to accept client. Exit gracefully.
                 return
             else
-                throw(y)
+                throw(e)
             end
         end
         try

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,7 +44,6 @@ facts("HttpServer runs") do
             @fact haskey(cookie.attrs, "Secure") --> true
         end
 
-
         ret = Requests.get("http://localhost:8000/bad")
         @fact text(ret) --> ""
         @fact statuscode(ret) --> 404

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,6 +47,34 @@ facts("HttpServer runs") do
         ret = Requests.get("http://localhost:8000/bad")
         @fact text(ret) --> ""
         @fact statuscode(ret) --> 404
+        close(server)
+    end
+
+    context("Rerun test using HTTP protocol on 0.0.0.0:8000 after closing") do
+        http = HttpHandler() do req::Request, res::Response
+            res = Response( ismatch(r"^/hello/",req.resource) ? string("Hello ", split(req.resource,'/')[3], "!") : 404 )
+            setcookie!(res, "sessionkey", "abc", Dict("Path"=>"/test", "Secure"=>""))
+        end
+        server = Server(http)
+        @async run(server, 8000)
+        sleep(1.0)
+
+        ret = Requests.get("http://localhost:8000/hello/travis")
+
+        @fact text(ret) --> "Hello travis!"
+        @fact statuscode(ret) --> 200
+        @fact haskey(ret.cookies, "sessionkey") --> true
+
+        let cookie = ret.cookies["sessionkey"]
+            @fact cookie.value --> "abc"
+            @fact cookie.attrs["Path"] --> "/test"
+            @fact haskey(cookie.attrs, "Secure") --> true
+        end
+
+        ret = Requests.get("http://localhost:8000/bad")
+        @fact text(ret) --> ""
+        @fact statuscode(ret) --> 404
+        close(server)
     end
 
     context("using HTTP protocol on 127.0.0.1:8001") do
@@ -60,6 +88,21 @@ facts("HttpServer runs") do
         ret = Requests.get("http://127.0.0.1:8001/hello/travis")
         @fact text(ret) --> "Hello travis!"
         @fact statuscode(ret) --> 200
+        close(server)
+    end
+
+    context("Rerun test using HTTP protocol on 127.0.0.1:8001 after closing") do
+        http = HttpHandler() do req::Request, res::Response
+            Response( ismatch(r"^/hello/",req.resource) ? string("Hello ", split(req.resource,'/')[3], "!") : 404 )
+        end
+        server = Server(http)
+        @async run(server, host=ip"127.0.0.1", port=8001)
+        sleep(1.0)
+
+        ret = Requests.get("http://127.0.0.1:8001/hello/travis")
+        @fact text(ret) --> "Hello travis!"
+        @fact statuscode(ret) --> 200
+        close(server)
     end
 
     context("Testing HTTPS on port 8002") do
@@ -67,13 +110,30 @@ facts("HttpServer runs") do
             Response("hello")
         end
         server = Server(http)
-        cert = MbedTLS.crt_parse_file("cert.pem")
-        key = MbedTLS.parse_keyfile("key.pem")
+        cert = MbedTLS.crt_parse_file(Pkg.dir("HttpServer","test","cert.pem"))
+        key = MbedTLS.parse_keyfile(Pkg.dir("HttpServer","test","key.pem"))
         @async run(server, port=8002, ssl=(cert, key))
         sleep(1.0)
         client_tls_conf = Requests.TLS_VERIFY
         MbedTLS.ca_chain!(client_tls_conf, cert)
         ret = Requests.get("https://localhost:8002", tls_conf=client_tls_conf)
         @fact text(ret) --> "hello"
+        close(server)
+    end
+
+    context("Rerun test of HTTPS on port 8002 after closing") do
+        http = HttpHandler() do req, res
+            Response("hello")
+        end
+        server = Server(http)
+        cert = MbedTLS.crt_parse_file(Pkg.dir("HttpServer","test","cert.pem"))
+        key = MbedTLS.parse_keyfile(Pkg.dir("HttpServer","test","key.pem"))
+        @async run(server, port=8002, ssl=(cert, key))
+        sleep(1.0)
+        client_tls_conf = Requests.TLS_VERIFY
+        MbedTLS.ca_chain!(client_tls_conf, cert)
+        ret = Requests.get("https://localhost:8002", tls_conf=client_tls_conf)
+        @fact text(ret) --> "hello"
+        close(server)
     end
 end


### PR DESCRIPTION
Attempt 2 (Rookie alert)

This probably needs some work, but I wanted to put it out there so you can have a look.

Fixes #82 