### PR TITLE
add compatibility with HttpParser (libhttp_parser v2.6.2)

### DIFF
--- a/src/HttpServer.jl
+++ b/src/HttpServer.jl
@@ -474,6 +474,8 @@ function __init__()
     global const on_headers_complete_cb = cfunction(on_headers_complete, HTTP_CB...)
     global const on_body_cb = cfunction(on_body, HTTP_DATA_CB...)
     global const on_message_complete_cb = cfunction(on_message_complete, HTTP_CB...)
+    global const on_chunk_header_cb = cfunction(on_chunk_header, HTTP_CB...)
+    global const on_chunk_complete_cb = cfunction(on_chunk_complete, HTTP_CB...)
 end
 
 end # module HttpServer

--- a/src/RequestParser.jl
+++ b/src/RequestParser.jl
@@ -105,7 +105,13 @@ function on_message_complete(parser)
     return 0
 end
 
+function on_chunk_header(parser)
+    return 0
+end
 
+function on_chunk_complete(parser)
+    return 0
+end
 
 default_complete_cb(r::Request) = nothing
 
@@ -133,7 +139,8 @@ immutable ClientParser
         settings = ParserSettings(on_message_begin_cb, on_url_cb,
                                   on_status_complete_cb, on_header_field_cb,
                                   on_header_value_cb, on_headers_complete_cb,
-                                  on_body_cb, on_message_complete_cb)
+                                  on_body_cb, on_message_complete_cb,
+                                  on_chunk_header_cb, on_chunk_complete_cb)
 
         new(parser, settings)
     end


### PR DESCRIPTION
I updated request parser to support new version of HttpParser (libhttp_parser v2.6.2). This should solve #86, as soon as [JuliaWeb/HttpParser.jl#36](https://github.com/JuliaWeb/HttpParser.jl/pull/36) is merged.
