### PR TITLE
Fix depwarn: pointer_to_array -> unsafe_wrap

### DIFF
--- a/src/RequestParser.jl
+++ b/src/RequestParser.jl
@@ -83,7 +83,7 @@ end
 function on_body(parser, at, len)
     r = pd(parser).request
     # write(pd(parser).data, convert(Ptr{UInt8}, at), len)
-    append!(r.data, pointer_to_array(convert(Ptr{UInt8}, at), (len,)))
+    append!(r.data, unsafe_wrap(Array,convert(Ptr{UInt8}, at), (len,)))
     r.data
     return 0
 end


### PR DESCRIPTION
Closes #97 

The first depwarn in #97 is fixed in HttpParser (will submit a PR), but this fixes the second depwarn.