### PR TITLE
HTTP/2 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ run(server, host=IPv4(127,0,0,1), port=8000)
 ```
 If you open up `localhost:8000/hello/name/` in your browser, you should get a greeting from the server.
 
+For HTTP/2 support, create a server with the second parameter set to true:
+
+```julia
+server = Server( http, true )
+```
+
 ---
 
 ```

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.4
 HttpCommon
 HttpParser
-MbedTLS
+MbedTLS 0.2.6
 Compat 0.7.16
+HTTP2 0.1.0

--- a/src/HttpServer.jl
+++ b/src/HttpServer.jl
@@ -144,6 +144,7 @@ end
 * Instantiate with both an `HttpHandler` and `WebSocketInterface` to serve
   both protocols.
 * Instantiate with just an `HttpHandler` to serve only standard `Http`
+* Instantiate with a `HttpHandler` and `true` to serve with HTTP/2.
 * Instantiate with just a `Function` to create an `HttpHandler` automatically
 * Instantiate with just a `WebSocketInterface` to only serve websockets
   requests and `404` all others.
@@ -383,6 +384,11 @@ end
 # backward compatibility method
 run(server::Server, port::Integer) = run(server, port=port)
 
+"""Handle HTTP/2 live connections.
+
+This function initialize to process a HTTP/2 client. It tries to use HTTP/2
+protocol upgrade first, and then call `process_client_callback2`.
+"""
 function process_client2(server::Server, client::Client; server_preface=false)
     CLIENT_PREFACE = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
     pre = readbytes(client.sock, length(CLIENT_PREFACE))
@@ -397,6 +403,11 @@ function process_client2(server::Server, client::Client; server_preface=false)
     end
 end
 
+"""Handle HTTP/2 live connections callback.
+
+This function processes after the initial HTTP/1.1 parser finished parsing
+headers (for HTTP/2 protocol upgrade) or directly enters a HTTP/2 connection.
+"""
 function process_client_callback2(server::Server, client::Client; skip_preface=false)
     connection = Session.new_connection(client.sock; isclient=false, skip_preface=skip_preface)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -137,7 +137,7 @@ facts("HttpServer runs") do
         close(server)
     end
 
-    context("Testing HTTPS on port 8002") do
+    context("Testing HTTPS with HTTP/2 on port 8002") do
         http = HttpHandler() do req, res
             Response("hello")
         end


### PR DESCRIPTION
This pull request adds HTTP/2 support for HttpServer.jl. Help on testing and code review are highly appreciated!

To make the test pass, you need to checkout `master` of [HPack.jl](http://github.com/sorpaas/HPack.jl) (header compression implementation), [HTTP2.jl](https://github.com/sorpaas/HTTP2.jl) (HTTP/2 protocol implementation), [MbedTLS.jl](https://github.com/JuliaWeb/MbedTLS.jl) and [Requests.jl](https://github.com/JuliaWeb/Requests.jl).

See test for usage example. Basically, to create a HTTP/2 server:

```
server = Server(http, true)
```

And then you can handle requests as normal.
