### PR TITLE
Restore compatibility with Unix sockets

### DIFF
--- a/src/HttpServer.jl
+++ b/src/HttpServer.jl
@@ -92,10 +92,10 @@ HttpServer.event(server, "foo", "Julia")
 """
 immutable HttpHandler
     handle::Function
-    sock::Base.TCPServer
+    sock::Base.IOServer
     events::Dict
 
-    HttpHandler(handle::Function, sock::Base.TCPServer) = new(handle, sock, defaultevents)
+    HttpHandler(handle::Function, sock::Base.IOServer) = new(handle, sock, defaultevents)
     HttpHandler(handle::Function) = new(handle, Base.TCPServer(), defaultevents)
 end
 handle(handler::HttpHandler, req::Request, res::Response) = handler.handle(req, res)


### PR DESCRIPTION
This is a fix for issue #103.

The `sock` member of the `HttpHandler` type is changed to an `IOServer` from a `TCPServer`. No other changes appear to be immediately necessary to restore this functionality.

To help ensure that Unix socket functionality isn't broken in the future, tests are added that verify that the server works via local unix sockets.

The unix socket client example is also updated to reflect changes in the `Requests` package that have broken the client example.

Both in the test cases and in the example, things get much more tangled with the innards of the `Requests` package than I'd like, but that seemed to be the easiest way to create the tests and fix the example given how the `Requests` package is currently written.
