### PR TITLE
Improve load time

### DIFF
--- a/src/HttpServer.jl
+++ b/src/HttpServer.jl
@@ -341,6 +341,7 @@ run(server, 8000)
 ```
 """
 function run(server::Server; args...)
+    initcbs()
     params = Dict(args)
 
     # parse parameters
@@ -468,7 +469,8 @@ function FileResponse(filename)
 end
 
 
-function __init__()
+function initcbs()
+    isdefined(HttpServer, :on_message_begin_cb) && return
     # Turn all the callbacks into C callable functions.
     global const on_message_begin_cb = cfunction(on_message_begin, HTTP_CB...)
     global const on_url_cb = cfunction(on_url, HTTP_DATA_CB...)


### PR DESCRIPTION
Although a little ugly, this small patch significantly improves load time, from ~0.5s to about 10x less on my machine. This is a big win for packages which indirectly depend on HttpServer but don't always need to use it.

Obviously it'd be nice to remove this once precompilation catches up.