### PR TITLE
More progress toward v0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,4 @@ julia 0.6
 HttpCommon
 HttpParser
 MbedTLS
-Compat 0.17.0
+Compat 0.33

--- a/src/RequestParser.jl
+++ b/src/RequestParser.jl
@@ -143,10 +143,10 @@ struct ClientParser
         http_parser_init(parser)
         parser.data.complete_cb = on_message_complete
 
-        settings = ParserSettings(on_message_begin_cb, on_url_cb,
-                                  on_status_complete_cb, on_header_field_cb,
-                                  on_header_value_cb, on_headers_complete_cb,
-                                  on_body_cb, on_message_complete_cb)
+        settings = ParserSettings(on_message_begin_cb[], on_url_cb[],
+                                  on_status_complete_cb[], on_header_field_cb[],
+                                  on_header_value_cb[], on_headers_complete_cb[],
+                                  on_body_cb[], on_message_complete_cb[])
 
         new(parser, settings)
     end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,1 @@
-FactCheck
 Requests


### PR DESCRIPTION
@MikeInnes this is a PR against the branch from #135 

I got most of the way towards making the tests work until I realized that the tests themselves require Requests.jl which is deprecated and not currently working on v0.7. I'm not sure what the path forward is: HTTP.jl has similar functionality to Requests, but that's a totally separate ecosystem, right? 

Anyway, assuming the tests can be fixed, I did the following: 
* Switched from FactCheck to (Base.)Test, since FactCheck is broken on v0.7 and no longer necessary
* Got rid of the `initcbs()` function entirely. As far as I can tell there's no reason to defer generating those callbacks until `run()` is called. Does `initcbs` predate the existence of module `__init__()` functions? I also changed from doing a `global const` inside the function (which wasn't actually const in v0.6 and is disallowed in v0.7+) to setting a global const `Ref`.